### PR TITLE
Consetita apertura immagini tonde

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     /* Libreria per serializzare su JSON */
     implementation 'com.google.code.gson:gson:2.8.5'
+    /* Libreria per aprire un'immagine tonda che diventa quadrata */
+    implementation 'com.appeaser.imagetransitionlibrary:imagetransitionlibrary:0.0.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,10 +41,10 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
     /* Libreria per zoomare le foto */
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    /* Libreria per serializzare su JSON */
-    implementation 'com.google.code.gson:gson:2.8.5'
     /* Libreria per aprire un'immagine tonda che diventa quadrata */
     implementation 'com.appeaser.imagetransitionlibrary:imagetransitionlibrary:0.0.1'
+    /* Libreria per serializzare su JSON */
+    implementation 'com.google.code.gson:gson:2.8.5'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
@@ -41,20 +41,17 @@ public class ImageDetailActivity extends AppCompatActivity {
         String imageUri = i.getStringExtra(EXTRA_IMAGE_URI);
         imageType = i.getStringExtra(EXTRA_IMAGE_TYPE);
 
-        /*PhotoView image = findViewById(R.id.activity_image_detail_img);
-        TransitionImageView imageRound = findViewById(R.id.activity_image_detail_img_round);*/
         ImageView image;
 
         // Riga necessaria per gestire l'animazione nel caso si apra un'immagine tonda
         if (imageType.equals(ImageUtils.IMAGE_TYPE_ROUND)) {
             setEnterSharedElementCallback(ImageTransitionUtil.DEFAULT_SHARED_ELEMENT_CALLBACK);
             image = findViewById(R.id.activity_image_detail_img_round);
+            // Animazione apertura immagine tonda
             getWindow().setSharedElementEnterTransition(TransitionInflater.from(ImageDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
             getWindow().setSharedElementExitTransition(TransitionInflater.from(ImageDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
-//            imageRound.setVisibility(View.VISIBLE);
         } else {
             image = findViewById(R.id.activity_image_detail_img);
-//            image.setVisibility(View.VISIBLE);
         }
         image.setVisibility(View.VISIBLE);
 

--- a/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
@@ -24,13 +24,16 @@ import com.unison.appartment.R;
 public class ImageDetailActivity extends AppCompatActivity {
 
     public final static String EXTRA_IMAGE_URI = "imageUri";
+    public final static String EXTRA_IMAGE_TYPE = "imageType";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_image_detail);
 
+        // Riga necessaria per gestire l'animazione nel caso si apra un'immagine tonda
         setEnterSharedElementCallback(ImageTransitionUtil.DEFAULT_SHARED_ELEMENT_CALLBACK);
+
         Intent i = getIntent();
         String imageUri = i.getStringExtra(EXTRA_IMAGE_URI);
         // Prima di avviare l'animazione si attende che l'immagine venga caricata

--- a/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
@@ -7,6 +7,9 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+
+import com.appeaser.imagetransitionlibrary.ImageTransitionUtil;
+import com.appeaser.imagetransitionlibrary.TransitionImageView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
@@ -27,10 +30,11 @@ public class ImageDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_image_detail);
 
+        setEnterSharedElementCallback(ImageTransitionUtil.DEFAULT_SHARED_ELEMENT_CALLBACK);
         Intent i = getIntent();
         String imageUri = i.getStringExtra(EXTRA_IMAGE_URI);
         // Prima di avviare l'animazione si attende che l'immagine venga caricata
-        PhotoView image = findViewById(R.id.activity_image_detail_img);
+        TransitionImageView image = findViewById(R.id.activity_image_detail_img);
         supportPostponeEnterTransition();
         Glide
                 .with(this)
@@ -48,5 +52,11 @@ public class ImageDetailActivity extends AppCompatActivity {
                     }
                 })
                 .into(image);
+    }
+
+    @Override
+    public void onBackPressed() {
+        supportFinishAfterTransition();
+        super.onBackPressed();
     }
 }

--- a/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
@@ -7,6 +7,9 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.transition.TransitionInflater;
+import android.view.View;
+import android.widget.ImageView;
 
 import com.appeaser.imagetransitionlibrary.ImageTransitionUtil;
 import com.appeaser.imagetransitionlibrary.TransitionImageView;
@@ -17,6 +20,7 @@ import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.github.chrisbanes.photoview.PhotoView;
 import com.unison.appartment.R;
+import com.unison.appartment.utils.ImageUtils;
 
 /**
  * Classe che rappresenta l'Activity con il dettaglio dell'immagine
@@ -26,18 +30,35 @@ public class ImageDetailActivity extends AppCompatActivity {
     public final static String EXTRA_IMAGE_URI = "imageUri";
     public final static String EXTRA_IMAGE_TYPE = "imageType";
 
+    private String imageType;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_image_detail);
 
-        // Riga necessaria per gestire l'animazione nel caso si apra un'immagine tonda
-        setEnterSharedElementCallback(ImageTransitionUtil.DEFAULT_SHARED_ELEMENT_CALLBACK);
-
         Intent i = getIntent();
         String imageUri = i.getStringExtra(EXTRA_IMAGE_URI);
+        imageType = i.getStringExtra(EXTRA_IMAGE_TYPE);
+
+        /*PhotoView image = findViewById(R.id.activity_image_detail_img);
+        TransitionImageView imageRound = findViewById(R.id.activity_image_detail_img_round);*/
+        ImageView image;
+
+        // Riga necessaria per gestire l'animazione nel caso si apra un'immagine tonda
+        if (imageType.equals(ImageUtils.IMAGE_TYPE_ROUND)) {
+            setEnterSharedElementCallback(ImageTransitionUtil.DEFAULT_SHARED_ELEMENT_CALLBACK);
+            image = findViewById(R.id.activity_image_detail_img_round);
+            getWindow().setSharedElementEnterTransition(TransitionInflater.from(ImageDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
+            getWindow().setSharedElementExitTransition(TransitionInflater.from(ImageDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
+//            imageRound.setVisibility(View.VISIBLE);
+        } else {
+            image = findViewById(R.id.activity_image_detail_img);
+//            image.setVisibility(View.VISIBLE);
+        }
+        image.setVisibility(View.VISIBLE);
+
         // Prima di avviare l'animazione si attende che l'immagine venga caricata
-        TransitionImageView image = findViewById(R.id.activity_image_detail_img);
         supportPostponeEnterTransition();
         Glide
                 .with(this)
@@ -57,9 +78,12 @@ public class ImageDetailActivity extends AppCompatActivity {
                 .into(image);
     }
 
+    // Metodo necessario per gestire l'animazione nel caso si apra un'immagine tonda
     @Override
     public void onBackPressed() {
-        supportFinishAfterTransition();
+        if (imageType.equals(ImageUtils.IMAGE_TYPE_ROUND)) {
+            supportFinishAfterTransition();
+        }
         super.onBackPressed();
     }
 }

--- a/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.appeaser.imagetransitionlibrary.TransitionImageView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.button.MaterialButton;
@@ -47,7 +48,7 @@ public class UserProfileActivity extends ActivityWithDialogs implements UserHome
     private DatabaseReader databaseReader;
 
     private View emptyListLayout;
-    private ImageView imgProfile;
+    private TransitionImageView imgProfile;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
@@ -7,6 +7,7 @@ import androidx.core.view.ViewCompat;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.transition.TransitionInflater;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -34,6 +35,7 @@ import com.unison.appartment.fragments.UserHomeListFragment;
 import com.unison.appartment.R;
 import com.unison.appartment.model.UserHome;
 import com.unison.appartment.utils.DateUtils;
+import com.unison.appartment.utils.ImageUtils;
 
 import java.text.ParseException;
 import java.util.Locale;
@@ -108,7 +110,11 @@ public class UserProfileActivity extends ActivityWithDialogs implements UserHome
                 Intent i = new Intent(UserProfileActivity.this, ImageDetailActivity.class);
                 ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                         UserProfileActivity.this, imgProfile, ViewCompat.getTransitionName(imgProfile));
+
+                getWindow().setSharedElementEnterTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
+                getWindow().setSharedElementExitTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
                 i.putExtra(ImageDetailActivity.EXTRA_IMAGE_URI, Appartment.getInstance().getUser().getImage());
+                i.putExtra(ImageDetailActivity.EXTRA_IMAGE_TYPE, ImageUtils.IMAGE_TYPE_ROUND);
                 startActivity(i, options.toBundle());
             }
         });

--- a/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
@@ -110,7 +110,7 @@ public class UserProfileActivity extends ActivityWithDialogs implements UserHome
                 Intent i = new Intent(UserProfileActivity.this, ImageDetailActivity.class);
                 ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                         UserProfileActivity.this, imgProfile, ViewCompat.getTransitionName(imgProfile));
-
+                // Animazione apertura immagine tonda
                 getWindow().setSharedElementEnterTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
                 getWindow().setSharedElementExitTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
                 i.putExtra(ImageDetailActivity.EXTRA_IMAGE_URI, Appartment.getInstance().getUser().getImage());

--- a/app/src/main/java/com/unison/appartment/fragments/MessagesFragment.java
+++ b/app/src/main/java/com/unison/appartment/fragments/MessagesFragment.java
@@ -14,6 +14,7 @@ import com.unison.appartment.R;
 import com.unison.appartment.fragments.InsertPostFragment.OnInsertPostFragmentListener;
 import com.unison.appartment.fragments.PostListFragment.OnPostListFragmentInteractionListener;
 import com.unison.appartment.activities.ImageDetailActivity;
+import com.unison.appartment.utils.ImageUtils;
 
 
 /**
@@ -68,6 +69,7 @@ public class MessagesFragment extends Fragment implements OnInsertPostFragmentLi
         ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                 getActivity(), image, ViewCompat.getTransitionName(image));
         i.putExtra(ImageDetailActivity.EXTRA_IMAGE_URI, imageUri);
+        i.putExtra(ImageDetailActivity.EXTRA_IMAGE_TYPE, ImageUtils.IMAGE_TYPE_SQUARE);
         startActivity(i, options.toBundle());
     }
 }

--- a/app/src/main/java/com/unison/appartment/state/MyApplication.java
+++ b/app/src/main/java/com/unison/appartment/state/MyApplication.java
@@ -12,6 +12,14 @@ public class MyApplication extends Application {
     public void onCreate() {
         super.onCreate();
         // TODO vedere se va tolto o qualche miglioramento lo dà lo stesso
+        /*
+        NB
+        Mantenere questa riga di codice abilita questa funzionalità: se si apre l'app, e si accede
+        con un utente, dopodiché si chiude l'app dalla schermata del profilo utente, si spegne la
+        rete e la si riapre allora l'app mostrerà comunque la lista delle case dell'utente.
+        Senza questa riga alla chiusura dell'app si perdono i dati e se la si riapre senza rete
+        si continua a vedere la progress bar.
+         */
         FirebaseDatabase.getInstance().setPersistenceEnabled(true);
         MyApplication.context = getApplicationContext();
     }

--- a/app/src/main/java/com/unison/appartment/state/MyApplication.java
+++ b/app/src/main/java/com/unison/appartment/state/MyApplication.java
@@ -3,12 +3,16 @@ package com.unison.appartment.state;
 import android.app.Application;
 import android.content.Context;
 
+import com.google.firebase.database.FirebaseDatabase;
+
 public class MyApplication extends Application {
 
     private static Context context;
 
     public void onCreate() {
         super.onCreate();
+        // TODO vedere se va tolto o qualche miglioramento lo dà lo stesso
+        FirebaseDatabase.getInstance().setPersistenceEnabled(true);
         MyApplication.context = getApplicationContext();
     }
 

--- a/app/src/main/java/com/unison/appartment/utils/ImageUtils.java
+++ b/app/src/main/java/com/unison/appartment/utils/ImageUtils.java
@@ -3,6 +3,10 @@ package com.unison.appartment.utils;
 import android.graphics.Bitmap;
 
 public class ImageUtils {
+    // Costanti usate per indicare se l'immagine considerata è tonda o quadrata
+    // Serve quando un'immagine viene aperta perché il codice è diveso
+    public final static String IMAGE_TYPE_ROUND = "0";
+    public final static String IMAGE_TYPE_SQUARE = "1";
 
     public final static int MAX_WIDTH = 680;
     public final static int MAX_HEIGHT = 680;

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".activities.ImageDetailActivity" >
 
-    <com.github.chrisbanes.photoview.PhotoView
+    <com.appeaser.imagetransitionlibrary.TransitionImageView
         android:id="@+id/activity_image_detail_img"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".activities.ImageDetailActivity" >
 
-    <com.appeaser.imagetransitionlibrary.TransitionImageView
+    <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/activity_image_detail_img"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -16,5 +16,21 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@tools:sample/avatars" />
+        tools:src="@tools:sample/avatars"
+        android:visibility="gone"/>
+
+    <com.appeaser.imagetransitionlibrary.TransitionImageView
+        android:id="@+id/activity_image_detail_img_round"
+        app:tiv_rounding="0"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:transitionName="@string/transition_open_image"
+        android:contentDescription="@string/activity_image_detail_img"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@tools:sample/avatars"
+        android:visibility="gone"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -94,9 +94,11 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent">
 
-                    <ImageView
+                    <com.appeaser.imagetransitionlibrary.TransitionImageView
                         android:id="@+id/activity_user_profile_img_profile"
                         style="@style/Component.ImageView.ProfileImage"
+                        android:scaleType="centerCrop"
+                        app:tiv_rounding="1"
                         android:transitionName="@string/transition_open_image"
                         android:contentDescription="@string/caption_profile_pic"
                         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
         <!-- Animazione immagine -->
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowSharedElementsUseOverlay">false</item>
+        <!-- Animazione immagine tonda -->
         <item name="android:windowSharedElementEnterTransition">@transition/itl_image_transition</item>
         <item name="android:windowSharedElementExitTransition">@transition/itl_image_transition</item>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,8 +11,8 @@
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowSharedElementsUseOverlay">false</item>
         <!-- Animazione immagine tonda -->
-        <item name="android:windowSharedElementEnterTransition">@transition/itl_image_transition</item>
-        <item name="android:windowSharedElementExitTransition">@transition/itl_image_transition</item>
+        <!--<item name="android:windowSharedElementEnterTransition">@transition/itl_image_transition</item>-->
+        <!--<item name="android:windowSharedElementExitTransition">@transition/itl_image_transition</item>-->
 
         <!-- Stile dei timestamp pickers -->
         <item name="android:datePickerDialogTheme">@style/CustomDatePickerDialogTheme</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,8 @@
         <!-- Animazione immagine -->
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowSharedElementsUseOverlay">false</item>
+        <item name="android:windowSharedElementEnterTransition">@transition/itl_image_transition</item>
+        <item name="android:windowSharedElementExitTransition">@transition/itl_image_transition</item>
 
         <!-- Stile dei timestamp pickers -->
         <item name="android:datePickerDialogTheme">@style/CustomDatePickerDialogTheme</item>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.google.gms:google-services:4.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Le immagini tonde si aprono con una bella animazione ma non sono zoomabili.
Le immagini siano esse quadrate o tonde si aprono attraverso l'uso della stessa classe 🚀 

Abilitato `setPersistenceEnabled(true)` che consente di mantenere i dati anche quando si chiude completamente l'app e la si riapre con la rete spenta