### PR TITLE
Corretta apertura immagine tonda

### DIFF
--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -19,11 +19,14 @@
         tools:src="@tools:sample/avatars"
         android:visibility="gone"/>
 
+    <!-- Con questi attributi l'immagine si apre a tutto schermo ma viene leggermente tagliata -->
+    <!--android:layout_width="wrap_content" -->
+    <!--android:layout_height="wrap_content"-->
     <com.appeaser.imagetransitionlibrary.TransitionImageView
         android:id="@+id/activity_image_detail_img_round"
         app:tiv_rounding="0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="300dp"
         android:scaleType="centerCrop"
         android:transitionName="@string/transition_open_image"
         android:contentDescription="@string/activity_image_detail_img"


### PR DESCRIPTION
Adesso l'immagine tonda (che si può trovare, ad esempio, nella `UserProfileActivity`) può essere aperta senza che l'immagine sia tagliata, però non viene aperta a tutto schermo.
Dato che non capivo come nell'esempio della libreria tutto funzionasse mi sono scaricato il codice e l'ho runnato sul telefono. Il loro esempio va perché hanno una `layout_height` fissata a 300dp, infatti impostando a tutto schermo anche la loro viene tagliata.

Pertanto ora ho messo anche io 300dp e non taglia. Se preferiamo tutto schermo (ma che  taglia, ed è inevitabile) possiamo tornare sempre indietro (ho lasciato il vecchio codice come commento).

Fixes #122 