### PR TITLE
Cambiato nuovamente apertura immagine tonda

### DIFF
--- a/app/src/main/java/com/unison/appartment/activities/FamilyMemberDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/FamilyMemberDetailActivity.java
@@ -105,8 +105,8 @@ public class FamilyMemberDetailActivity extends AppCompatActivity {
                     ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                             FamilyMemberDetailActivity.this, image, ViewCompat.getTransitionName(image));
                     // Animazione apertura immagine tonda
-                    getWindow().setSharedElementEnterTransition(TransitionInflater.from(FamilyMemberDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
-                    getWindow().setSharedElementExitTransition(TransitionInflater.from(FamilyMemberDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
+                    /*getWindow().setSharedElementEnterTransition(TransitionInflater.from(FamilyMemberDetailActivity.this).inflateTransition(R.transition.itl_image_transition));
+                    getWindow().setSharedElementExitTransition(TransitionInflater.from(FamilyMemberDetailActivity.this).inflateTransition(R.transition.itl_image_transition));*/
                     i.putExtra(ImageDetailActivity.EXTRA_IMAGE_URI, member.getImage());
                     i.putExtra(ImageDetailActivity.EXTRA_IMAGE_TYPE, ImageUtils.IMAGE_TYPE_ROUND);
                     startActivity(i, options.toBundle());

--- a/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/UserProfileActivity.java
@@ -261,8 +261,8 @@ public class UserProfileActivity extends ActivityWithDialogs implements UserHome
                 ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                         UserProfileActivity.this, imgProfile, ViewCompat.getTransitionName(imgProfile));
                 // Animazione apertura immagine tonda
-                getWindow().setSharedElementEnterTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
-                getWindow().setSharedElementExitTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
+                /*getWindow().setSharedElementEnterTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));
+                getWindow().setSharedElementExitTransition(TransitionInflater.from(UserProfileActivity.this).inflateTransition(R.transition.itl_image_transition));*/
                 i.putExtra(ImageDetailActivity.EXTRA_IMAGE_URI, Appartment.getInstance().getUser().getImage());
                 i.putExtra(ImageDetailActivity.EXTRA_IMAGE_TYPE, ImageUtils.IMAGE_TYPE_ROUND);
                 startActivity(i, options.toBundle());

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -19,14 +19,11 @@
         tools:src="@tools:sample/avatars"
         android:visibility="gone"/>
 
-    <!-- Con questi attributi l'immagine si apre a tutto schermo ma viene leggermente tagliata -->
-    <!--android:layout_width="wrap_content" -->
-    <!--android:layout_height="wrap_content"-->
     <com.appeaser.imagetransitionlibrary.TransitionImageView
         android:id="@+id/activity_image_detail_img_round"
         app:tiv_rounding="0"
-        android:layout_width="match_parent"
-        android:layout_height="300dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:scaleType="centerCrop"
         android:transitionName="@string/transition_open_image"
         android:contentDescription="@string/activity_image_detail_img"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,8 +36,8 @@
                 <TextView
                     android:id="@+id/activity_main_text_points_value"
                     style="@style/Component.TextView.SingleLine.PointsValue"
-                    android:text="@string/placeholder_number"
                     android:textColor="@color/colorPrimaryText"
+                    android:text="0"
                     app:layout_constraintBottom_toTopOf="@id/activity_main_text_points_name"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Dopo varie prove ho visto che l'altezza fissa di 300dp funziona solo per
immagini landscape (anche nella libreria) e quindi per immagini portrait
si ha ancora quel glitch che c'era all'inizio. Pertanto ho rimesso 
l'immagine full screen (che viene in parte tagliata)
Ho anche commentato del codice che non serviva in realtà