### PR TITLE
Feature/network handling

### DIFF
--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
@@ -1,14 +1,9 @@
 package com.unison.appartment.activities;
 
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import com.unison.appartment.fragments.FirebaseErrorDialogFragment;
 import com.unison.appartment.fragments.FirebaseProgressDialogFragment;
-import com.unison.appartment.fragments.NetworkErrorDialogFragment;
-import com.unison.appartment.utils.NetworkStateReceiver;
-import com.unison.appartment.utils.NetworkStateReceiver.NetworkStateReceiverListener;
 
 /**
  * Classe astratta che rappresenta una generica activity in cui vengono visualizzati dei

--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
@@ -3,13 +3,7 @@ package com.unison.appartment.activities;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.os.PersistableBundle;
-import android.util.Log;
-
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
-
-import com.google.android.material.textfield.TextInputLayout;
 import com.unison.appartment.fragments.FirebaseErrorDialogFragment;
 import com.unison.appartment.fragments.FirebaseProgressDialogFragment;
 import com.unison.appartment.fragments.NetworkErrorDialogFragment;

--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
@@ -7,6 +7,7 @@ import android.os.PersistableBundle;
 import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 
 import com.google.android.material.textfield.TextInputLayout;
 import com.unison.appartment.fragments.FirebaseErrorDialogFragment;
@@ -34,7 +35,6 @@ public abstract class ActivityWithDialogs extends AppCompatActivity implements
      */
     private NetworkStateReceiver networkStateReceiver;
     // Dialog che mostra l'errore di rete
-    private NetworkErrorDialogFragment dialog;
 
     /**
      * Activity a cui si ritorna dopo la chiusura dell'ErrorDialog.
@@ -82,21 +82,20 @@ public abstract class ActivityWithDialogs extends AppCompatActivity implements
 
     @Override
     public void networkAvailable() {
-        Log.d("RETE", "On");
         // Se il dialog di errore di rete è mostrato allora lo nascondo.
         // Questo controllo è necessario perché all'apertura dell'app se la rete è presente il dialog
         // non è mai stato mostrato e quindi non faccio dismiss() su un null
+        NetworkErrorDialogFragment dialog = (NetworkErrorDialogFragment)getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
         if (dialog != null) {
             dialog.dismiss();
-            dialog = null;
         }
     }
 
     @Override
     public void networkUnavailable() {
-        Log.d("RETE", "Off");
-        dialog = new NetworkErrorDialogFragment();
-        dialog.show(getSupportFragmentManager(), NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
+        if (getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG) == null) {
+            new NetworkErrorDialogFragment().show(getSupportFragmentManager(), NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
+        }
     }
 
     /**

--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithDialogs.java
@@ -20,15 +20,8 @@ import com.unison.appartment.utils.NetworkStateReceiver.NetworkStateReceiverList
  * chiuso a seguito di un'azione dell'utente dal momento che non presenta bottoni o elementi con
  * cui l'utente può interagire).
  */
-public abstract class ActivityWithDialogs extends AppCompatActivity implements
-        FirebaseErrorDialogFragment.FirebaseErrorDialogInterface, NetworkStateReceiverListener,
-        NetworkErrorDialogFragment.NetworkErrorDialogInterface {
-
-    /**
-     * Broadcast receiver che si occupa di monitorare costantemente lo stato della rete
-     */
-    private NetworkStateReceiver networkStateReceiver;
-    // Dialog che mostra l'errore di rete
+public abstract class ActivityWithDialogs extends ActivityWithNetworkConnectionDialog implements
+        FirebaseErrorDialogFragment.FirebaseErrorDialogInterface {
 
     /**
      * Activity a cui si ritorna dopo la chiusura dell'ErrorDialog.
@@ -55,43 +48,6 @@ public abstract class ActivityWithDialogs extends AppCompatActivity implements
                 .findFragmentByTag(FirebaseProgressDialogFragment.TAG_FIREBASE_PROGRESS_DIALOG);
     }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        // Quando l'activity non è più visibile rimuovo il listener che riceve gli
-        // aggiornamenti sullo stato della rete
-        networkStateReceiver.removeListener(this);
-        this.unregisterReceiver(networkStateReceiver);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // Quando l'activity torna ad essere visibile riaggiungo il listener che riceve gli
-        // aggiornamenti sullo stato della rete
-        networkStateReceiver = new NetworkStateReceiver();
-        networkStateReceiver.addListener(this);
-        this.registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
-    }
-
-    @Override
-    public void networkAvailable() {
-        // Se il dialog di errore di rete è mostrato allora lo nascondo.
-        // Questo controllo è necessario perché all'apertura dell'app se la rete è presente il dialog
-        // non è mai stato mostrato e quindi non faccio dismiss() su un null
-        NetworkErrorDialogFragment dialog = (NetworkErrorDialogFragment)getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
-        if (dialog != null) {
-            dialog.dismiss();
-        }
-    }
-
-    @Override
-    public void networkUnavailable() {
-        if (getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG) == null) {
-            new NetworkErrorDialogFragment().show(getSupportFragmentManager(), NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
-        }
-    }
-
     /**
      * Mostra l'AlertDialog con cui viene comunicata all'utente una situazione di errore.
      */
@@ -116,11 +72,6 @@ public abstract class ActivityWithDialogs extends AppCompatActivity implements
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(i);
         finish();
-    }
-
-    @Override
-    public void onNetworkErrorDialogFragmentDismiss() {
-        finishAndRemoveTask();
     }
 
     /**

--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithNetworkConnectionDialog.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithNetworkConnectionDialog.java
@@ -56,6 +56,6 @@ public abstract class ActivityWithNetworkConnectionDialog extends AppCompatActiv
 
     @Override
     public void onNetworkErrorDialogFragmentDismiss() {
-        finishAndRemoveTask();
+        moveTaskToBack(true);
     }
 }

--- a/app/src/main/java/com/unison/appartment/activities/ActivityWithNetworkConnectionDialog.java
+++ b/app/src/main/java/com/unison/appartment/activities/ActivityWithNetworkConnectionDialog.java
@@ -1,0 +1,61 @@
+package com.unison.appartment.activities;
+
+import android.content.IntentFilter;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.unison.appartment.fragments.NetworkErrorDialogFragment;
+import com.unison.appartment.fragments.NetworkErrorDialogFragment.NetworkErrorDialogInterface;
+import com.unison.appartment.utils.NetworkStateReceiver;
+import com.unison.appartment.utils.NetworkStateReceiver.NetworkStateReceiverListener;
+
+public abstract class ActivityWithNetworkConnectionDialog extends AppCompatActivity
+        implements NetworkStateReceiverListener, NetworkErrorDialogInterface {
+
+    /**
+     * Broadcast receiver che si occupa di monitorare costantemente lo stato della rete
+     */
+    private NetworkStateReceiver networkStateReceiver;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        // Quando l'activity non è più visibile rimuovo il listener che riceve gli
+        // aggiornamenti sullo stato della rete
+        networkStateReceiver.removeListener(this);
+        this.unregisterReceiver(networkStateReceiver);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Quando l'activity torna ad essere visibile riaggiungo il listener che riceve gli
+        // aggiornamenti sullo stato della rete
+        networkStateReceiver = new NetworkStateReceiver();
+        networkStateReceiver.addListener(this);
+        this.registerReceiver(networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
+    }
+
+    @Override
+    public void networkAvailable() {
+        // Se il dialog di errore di rete è mostrato allora lo nascondo.
+        // Questo controllo è necessario perché all'apertura dell'app se la rete è presente il dialog
+        // non è mai stato mostrato e quindi non faccio dismiss() su un null
+        NetworkErrorDialogFragment dialog = (NetworkErrorDialogFragment)getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
+        if (dialog != null) {
+            dialog.dismiss();
+        }
+    }
+
+    @Override
+    public void networkUnavailable() {
+        if (getSupportFragmentManager().findFragmentByTag(NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG) == null) {
+            new NetworkErrorDialogFragment().show(getSupportFragmentManager(), NetworkErrorDialogFragment.TAG_NETWORK_ERROR_DIALOG);
+        }
+    }
+
+    @Override
+    public void onNetworkErrorDialogFragmentDismiss() {
+        finishAndRemoveTask();
+    }
+}

--- a/app/src/main/java/com/unison/appartment/activities/ChartActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ChartActivity.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-public class ChartActivity extends AppCompatActivity {
+public class ChartActivity extends ActivityWithNetworkConnectionDialog {
 
     private final static double PIE_MIN_PERCENTAGE_SHOWN = 0.05;
     private final static double PIE_CUMULATED_PERCENTAGE_LIMIT = 0.9;

--- a/app/src/main/java/com/unison/appartment/activities/CompletedTaskDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/CompletedTaskDetailActivity.java
@@ -26,7 +26,7 @@ import com.unison.appartment.utils.DateUtils;
 
 import java.util.Date;
 
-public class CompletedTaskDetailActivity extends AppCompatActivity implements CompletionListFragment.OnCompletionListFragmentInteractionListener {
+public class CompletedTaskDetailActivity extends ActivityWithNetworkConnectionDialog implements CompletionListFragment.OnCompletionListFragmentInteractionListener {
 
     public final static String EXTRA_COMPLETED_TASK_OBJECT = "completedTaskObject";
 

--- a/app/src/main/java/com/unison/appartment/activities/EnterActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/EnterActivity.java
@@ -14,7 +14,7 @@ import com.unison.appartment.state.Appartment;
 /**
  * Classe che rappresenta l'Activity per entrare nell'applicazione, registrandosi oppure accedendo
  */
-public class EnterActivity extends AppCompatActivity {
+public class EnterActivity extends ActivityWithNetworkConnectionDialog {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/unison/appartment/activities/EnterActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/EnterActivity.java
@@ -14,7 +14,7 @@ import com.unison.appartment.state.Appartment;
 /**
  * Classe che rappresenta l'Activity per entrare nell'applicazione, registrandosi oppure accedendo
  */
-public class EnterActivity extends ActivityWithNetworkConnectionDialog {
+public class EnterActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/ImageDetailActivity.java
@@ -25,7 +25,7 @@ import com.unison.appartment.utils.ImageUtils;
 /**
  * Classe che rappresenta l'Activity con il dettaglio dell'immagine
  */
-public class ImageDetailActivity extends AppCompatActivity {
+public class ImageDetailActivity extends ActivityWithNetworkConnectionDialog {
 
     public final static String EXTRA_IMAGE_URI = "imageUri";
     public final static String EXTRA_IMAGE_TYPE = "imageType";

--- a/app/src/main/java/com/unison/appartment/activities/MainActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/MainActivity.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * Classe che rappresenta l'Activity principale di una Home
  */
-public class MainActivity extends AppCompatActivity implements DeleteHomeUserConfirmationDialogFragment.ConfirmationDialogInterface {
+public class MainActivity extends ActivityWithNetworkConnectionDialog implements DeleteHomeUserConfirmationDialogFragment.ConfirmationDialogInterface {
 
     /*
     Costanti che indicano la posizione delle varie sezioni così come ordinate nella bottom

--- a/app/src/main/java/com/unison/appartment/activities/RewardDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/RewardDetailActivity.java
@@ -26,7 +26,7 @@ import com.unison.appartment.state.Appartment;
 /**
  * Classe che rappresenta l'Activity con il dettaglio del Reward
  */
-public class RewardDetailActivity extends AppCompatActivity {
+public class RewardDetailActivity extends ActivityWithNetworkConnectionDialog {
 
     public final static String EXTRA_REWARD_OBJECT = "rewardObject";
 

--- a/app/src/main/java/com/unison/appartment/activities/TaskDetailActivity.java
+++ b/app/src/main/java/com/unison/appartment/activities/TaskDetailActivity.java
@@ -32,7 +32,7 @@ import java.util.Date;
 /**
  * Classe che rappresenta l'Activity con il dettaglio del UncompletedTask
  */
-public class TaskDetailActivity extends AppCompatActivity implements UserPickerFragment.OnUserPickerFragmentInteractionListener {
+public class TaskDetailActivity extends ActivityWithNetworkConnectionDialog implements UserPickerFragment.OnUserPickerFragmentInteractionListener {
 
     public final static String EXTRA_TASK_OBJECT = "taskObject";
 

--- a/app/src/main/java/com/unison/appartment/fragments/NetworkErrorDialogFragment.java
+++ b/app/src/main/java/com/unison/appartment/fragments/NetworkErrorDialogFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
 
 import com.unison.appartment.R;
 
@@ -19,7 +20,7 @@ import com.unison.appartment.R;
  */
 public class NetworkErrorDialogFragment extends DialogFragment {
 
-    public final static String TAG_NETWORK_ERROR_DIALOG = "NetworkErrorDialog";
+    public final static String TAG_NETWORK_ERROR_DIALOG = "networkErrorDialog";
 
     public interface NetworkErrorDialogInterface {
         void onNetworkErrorDialogFragmentDismiss();

--- a/app/src/main/java/com/unison/appartment/fragments/NetworkErrorDialogFragment.java
+++ b/app/src/main/java/com/unison/appartment/fragments/NetworkErrorDialogFragment.java
@@ -1,0 +1,59 @@
+package com.unison.appartment.fragments;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.unison.appartment.R;
+
+// Riferimento per la struttura del codice: https://stackoverflow.com/a/13338148
+
+/**
+ * Fragment che rappresenta una dialog di errore di Firebase
+ */
+public class NetworkErrorDialogFragment extends DialogFragment {
+
+    public final static String TAG_NETWORK_ERROR_DIALOG = "NetworkErrorDialog";
+
+    public interface NetworkErrorDialogInterface {
+        void onNetworkErrorDialogFragmentDismiss();
+    }
+
+    private NetworkErrorDialogInterface mListener;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        mListener = (NetworkErrorDialogInterface) context;
+        super.onAttach(context);
+    }
+
+    @Override
+    public void onDetach() {
+        mListener = null;
+        super.onDetach();
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage(R.string.dialog_network_error_message)
+                .setPositiveButton(R.string.general_ok_button, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        mListener.onNetworkErrorDialogFragmentDismiss();
+                    }
+                });
+
+        AlertDialog dialog = builder.create();
+        setCancelable(false);
+        dialog.setCanceledOnTouchOutside(false);
+        return dialog;
+    }
+
+}

--- a/app/src/main/java/com/unison/appartment/utils/NetworkStateReceiver.java
+++ b/app/src/main/java/com/unison/appartment/utils/NetworkStateReceiver.java
@@ -1,0 +1,66 @@
+package com.unison.appartment.utils;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class NetworkStateReceiver extends BroadcastReceiver {
+
+    protected Set<NetworkStateReceiverListener> listeners;
+    protected Boolean connected;
+
+    public NetworkStateReceiver() {
+        listeners = new HashSet<NetworkStateReceiverListener>();
+        connected = null;
+    }
+
+    public void onReceive(Context context, Intent intent) {
+        if(intent == null || intent.getExtras() == null)
+            return;
+
+        ConnectivityManager manager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo ni = manager.getActiveNetworkInfo();
+
+        if(ni != null && ni.getState() == NetworkInfo.State.CONNECTED) {
+            connected = true;
+        } else if(intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY,Boolean.FALSE)) {
+            connected = false;
+        }
+
+        notifyStateToAll();
+    }
+
+    private void notifyStateToAll() {
+        for(NetworkStateReceiverListener listener : listeners)
+            notifyState(listener);
+    }
+
+    private void notifyState(NetworkStateReceiverListener listener) {
+        if(connected == null || listener == null)
+            return;
+
+        if(connected == true)
+            listener.networkAvailable();
+        else
+            listener.networkUnavailable();
+    }
+
+    public void addListener(NetworkStateReceiverListener l) {
+        listeners.add(l);
+        notifyState(l);
+    }
+
+    public void removeListener(NetworkStateReceiverListener l) {
+        listeners.remove(l);
+    }
+
+    public interface NetworkStateReceiverListener {
+        public void networkAvailable();
+        public void networkUnavailable();
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,5 +276,6 @@
     <string name="activity_chart_title">Statistiche</string>
     <string name="fragment_family_btn_stats">Visualizza statistiche</string>
     <string name="activity_chart_empty_list_text">Non c\'è nessuna statistica da visualizzare.</string>
+    <string name="dialog_network_error_message">Nessuna connessione disponibile.\nConnettersi ad Internet e riprovare.</string>
 
 </resources>


### PR DESCRIPTION
Gestita presenza/assenza rete in tutte le activity.
Nel caso si perda la connettività compare un dialog contenente il solo pulsante 'OK' che mette l'app in background. Se si riapre l'applicazione si rientrerà nella stessa activity in cui si era prima e il dialog sarà presente o meno a seconda del fatto che sia abbia la connessione a internet o no.