### PR TITLE
Corretto errore nella visualizzazione delle notifiche

### DIFF
--- a/app/src/main/java/com/unison/appartment/receivers/NetworkStateReceiver.java
+++ b/app/src/main/java/com/unison/appartment/receivers/NetworkStateReceiver.java
@@ -44,7 +44,7 @@ public class NetworkStateReceiver extends BroadcastReceiver {
         if(connected == null || listener == null)
             return;
 
-        if(connected == true)
+        if(connected)
             listener.networkAvailable();
         else
             listener.networkUnavailable();

--- a/app/src/main/java/com/unison/appartment/services/AppartmentService.java
+++ b/app/src/main/java/com/unison/appartment/services/AppartmentService.java
@@ -70,7 +70,6 @@ public class AppartmentService extends Service {
                 else {
                     Intent intent = new Intent();
                     intent.setAction(Appartment.EVENT_HOME_DELETE);
-                    intent.putExtra(UserProfileActivity.EXTRA_SNACKBAR_MESSAGE, getString(R.string.snackbar_home_deleted_message));
                     LocalBroadcastManager.getInstance(AppartmentService.this).sendBroadcast(intent);
                 }
             }

--- a/app/src/main/java/com/unison/appartment/services/NotificationService.java
+++ b/app/src/main/java/com/unison/appartment/services/NotificationService.java
@@ -301,8 +301,8 @@ public class NotificationService extends Service {
                                     getString(R.string.notification_new_reward_request_title),
                                     getString(R.string.notification_new_reward_request_content),
                                     NotificationCompat.PRIORITY_DEFAULT,
-                                    false,
-                                    ""
+                                    true,
+                                    getString(R.string.notification_new_reward_request_content)
                             ));
 
                             if (!rewardNotificationAlreadyDispatched) {
@@ -382,8 +382,8 @@ public class NotificationService extends Service {
                                     getString(R.string.notification_new_task_request_title),
                                     getString(R.string.notification_new_task_request_content),
                                     NotificationCompat.PRIORITY_DEFAULT,
-                                    false,
-                                    ""
+                                    true,
+                                    getString(R.string.notification_new_task_request_content)
                             ));
 
                             if (!taskNotificationAlreadyDispatched) {
@@ -479,8 +479,8 @@ public class NotificationService extends Service {
                             getString(R.string.notification_role_changed_title),
                             notificationContent,
                             NotificationCompat.PRIORITY_HIGH,
-                            false,
-                            ""
+                            true,
+                            notificationContent
                     ));
 
                     if (!messageNotificationAlreadyDispatched) {
@@ -515,8 +515,8 @@ public class NotificationService extends Service {
                             getString(R.string.notification_user_kicked_title),
                             getString(R.string.notification_user_kicked_content, userHome.getHomename()),
                             NotificationCompat.PRIORITY_HIGH,
-                            false,
-                            ""
+                            true,
+                            getString(R.string.notification_user_kicked_content, userHome.getHomename())
                     ));
 
                     currentlyDisplayedNotifications.put(HOME_STATUS_CHANNEL_ID, notificationId);


### PR DESCRIPTION
Aggiunto `bigText` a tutte quante le notifiche per far sì che si possano espandere anche sui device in cui il testo della notifica non ci sta su una riga sola