### PR TITLE
Corretto errore grafico visualizzato all'aggiornamento di un'attività

### DIFF
--- a/app/src/main/java/com/unison/appartment/adapters/MyTodoListRecyclerViewAdapter.java
+++ b/app/src/main/java/com/unison/appartment/adapters/MyTodoListRecyclerViewAdapter.java
@@ -50,15 +50,22 @@ public class MyTodoListRecyclerViewAdapter extends ListAdapter<UncompletedTask, 
         Resetto le view ai valori di default (solo per i campi che non sono comunque resettati ad un
         altro valore) in modo che se il ViewHolder è stato riciclato non mi trovo risultati strani.
          */
-        holder.itemIcon.setImageDrawable(res.getDrawable(R.drawable.ic_check, null));
         holder.itemIcon.setColorFilter(res.getColor(R.color.colorPrimaryDark, null));
-        holder.taskAssignedUser.setVisibility(View.GONE);
-
         holder.taskName.setText(uncompletedTask.getName());
         holder.taskDescription.setText(uncompletedTask.getDescription());
         holder.textStatusUpper.setText(String.valueOf(uncompletedTask.getPoints()));
         holder.textStatusUpper.setTextSize(TypedValue.COMPLEX_UNIT_PX, res.getDimensionPixelSize(R.dimen.text_extra_large));
         holder.textStatusLower.setText(R.string.general_points_name);
+
+        /*
+        Il reset di icona e campi di testo sono inseriti in questo if per evitare glitch grafici
+        nel caso in cui il task sia assegnato (quando viene aggiornato un elemento, il rispettivo
+        list item è modificato due volte in pochi istanti originando un brutto effetto grafico).
+         */
+        if (!uncompletedTask.isAssigned()) {
+            holder.itemIcon.setImageDrawable(res.getDrawable(R.drawable.ic_check, null));
+            holder.taskAssignedUser.setVisibility(View.GONE);
+        }
 
         if (uncompletedTask.isAssigned()) {
             holder.itemIcon.setImageDrawable(res.getDrawable(R.drawable.ic_check_circle, null));

--- a/app/src/main/java/com/unison/appartment/fragments/TodoFragment.java
+++ b/app/src/main/java/com/unison/appartment/fragments/TodoFragment.java
@@ -130,13 +130,18 @@ public class TodoFragment extends Fragment implements TodoListFragment.OnTodoLis
                         listFragment.deleteTask(taskId);
                         break;
                     case OPERATION_ASSIGN:
-                        UncompletedTask task = (UncompletedTask) data.getParcelableExtra(EXTRA_TASK_DATA);
+                        UncompletedTask task = data.getParcelableExtra(EXTRA_TASK_DATA);
                         if (task.isAssigned()) {
-                            listFragment.removeAssignment(task.getId(), task.getAssignedUserId());
+                            listFragment.switchAssignment(task.getId(),
+                                    task.getAssignedUserId(),
+                                    data.getStringExtra(EXTRA_USER_ID),
+                                    data.getStringExtra(EXTRA_USER_NAME));
                         }
-                        listFragment.assignTask(task.getId(),
-                                data.getStringExtra(EXTRA_USER_ID),
-                                data.getStringExtra(EXTRA_USER_NAME));
+                        else {
+                            listFragment.assignTask(task.getId(),
+                                    data.getStringExtra(EXTRA_USER_ID),
+                                    data.getStringExtra(EXTRA_USER_NAME));
+                        }
                         break;
                     case OPERATION_REMOVE_ASSIGNMENT:
                         listFragment.removeAssignment(data.getStringExtra(EXTRA_TASK_ID),

--- a/app/src/main/java/com/unison/appartment/fragments/TodoListFragment.java
+++ b/app/src/main/java/com/unison/appartment/fragments/TodoListFragment.java
@@ -157,6 +157,10 @@ public class TodoListFragment extends Fragment {
         viewModel.removeAssignment(taskId, assignedUserId);
     }
 
+    public void switchAssignment(String taskId, String assignedUserId, String newAssignedUserId, String newAssignedUserName) {
+        viewModel.switchAssignment(taskId, assignedUserId, newAssignedUserId, newAssignedUserName);
+    }
+
     public void markTask(String taskId, String userId, String userName) {
         viewModel.markTask(taskId, userId, userName);
     }

--- a/app/src/main/java/com/unison/appartment/repository/TodoTaskRepository.java
+++ b/app/src/main/java/com/unison/appartment/repository/TodoTaskRepository.java
@@ -147,6 +147,37 @@ public class TodoTaskRepository {
         });
     }
 
+    public void switchAssignment(String taskId, String assignedUserId, String newAssignedUserId, String newAssignedUserName) {
+        String homeName = Appartment.getInstance().getHome().getName();
+        String uncompletedTaskPath = DatabaseConstants.UNCOMPLETEDTASKS +
+                DatabaseConstants.SEPARATOR + homeName + DatabaseConstants.SEPARATOR +
+                taskId;
+        String oldHomeUserRefPath = DatabaseConstants.HOMEUSERSREFS + DatabaseConstants.SEPARATOR +
+                homeName + DatabaseConstants.SEPARATOR + assignedUserId + DatabaseConstants.SEPARATOR +
+                DatabaseConstants.HOMEUSERSREFS_HOMENAME_UID_TASKS + DatabaseConstants.SEPARATOR +
+                taskId;
+        String newHomeUserRefPath = DatabaseConstants.HOMEUSERSREFS + DatabaseConstants.SEPARATOR +
+                homeName + DatabaseConstants.SEPARATOR + newAssignedUserId + DatabaseConstants.SEPARATOR +
+                DatabaseConstants.HOMEUSERSREFS_HOMENAME_UID_TASKS + DatabaseConstants.SEPARATOR +
+                taskId;
+
+        Map<String, Object> childUpdates = new HashMap<>();
+        childUpdates.put(uncompletedTaskPath + DatabaseConstants.SEPARATOR + DatabaseConstants.UNCOMPLETEDTASKS_HOMENAME_TASKID_ASSIGNEDUSERID, newAssignedUserId);
+        childUpdates.put(uncompletedTaskPath + DatabaseConstants.SEPARATOR + DatabaseConstants.UNCOMPLETEDTASKS_HOMENAME_TASKID_ASSIGNEDUSERNAME, newAssignedUserName);
+        // Tolgo l'id del task assegnato dai riferimenti associati al vecchio utente
+        childUpdates.put(oldHomeUserRefPath, null);
+        // Aggiungo l'id del task assegnato ai riferimenti associati al nuovo utente
+        childUpdates.put(newHomeUserRefPath, true);
+        rootRef.updateChildren(childUpdates).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                // C'è un errore e quindi lo notifico, ma subito dopo l'errore non c'è più
+                error.setValue(true);
+                error.setValue(false);
+            }
+        });
+    }
+
     public void markTask(String taskId, String userId, String userName) {
         String homeName = Appartment.getInstance().getHome().getName();
         String uncompletedTaskPath = DatabaseConstants.UNCOMPLETEDTASKS +

--- a/app/src/main/java/com/unison/appartment/viewmodel/TodoTaskViewModel.java
+++ b/app/src/main/java/com/unison/appartment/viewmodel/TodoTaskViewModel.java
@@ -46,6 +46,10 @@ public class TodoTaskViewModel extends ViewModel {
         repository.removeAssignment(taskId, assignedUserId);
     }
 
+    public void switchAssignment(String taskId, String assignedUserId, String newAssignedUserId, String newAssignedUserName) {
+        repository.switchAssignment(taskId, assignedUserId, newAssignedUserId, newAssignedUserName);
+    }
+
     public void markTask(String taskId, String userId, String userName) {
         repository.markTask(taskId, userId, userName);
     }


### PR DESCRIPTION
In precedenza, quando veniva cambiato l'assegnatario di un'attività, venivano fatte due scritture separate sul database il che poteva produrre un brutto effetto grafico sul device che riceveva le due operazioni separate. È stato creato un nuovo metodo `switchAssignment` che combina le due operazioni di annullamento dell'assegnamento precedente e registrazione del nuovo assegnamento in modo da far sì che i dispositivi ricevano un'unico aggiornamento.